### PR TITLE
Optimize block encryption in randomizer

### DIFF
--- a/src/shuffled/crypto.py
+++ b/src/shuffled/crypto.py
@@ -22,14 +22,12 @@ class AesRandomizer(Randomizer):
     domain_size = 2**128
 
     def __init__(self, key: bytes) -> None:
-        self._cipher = Cipher(
-            algorithms.AES(key), modes.ECB(), backend=default_backend()
-        )
+        cipher = Cipher(algorithms.AES(key), modes.ECB(), backend=default_backend())
+        self._encryptor = cipher.encryptor()
 
     def randomize(self, integer: int) -> int:
         encoded = integer.to_bytes(128, byteorder="big")
-        encryptor = self._cipher.encryptor()
-        encrypted = encryptor.update(encoded) + encryptor.finalize()
+        encrypted = self._encryptor.update(encoded)
         return int.from_bytes(encrypted, byteorder="big")
 
 


### PR DESCRIPTION
This significantly speeds up the computation of indexes (by a factor of about 6.5 for 10000 indexes, see benchmarking code).

The optimization works the following way: instead of creating a new encryptor for every iteration, we use the same encryptor every time. Since we use ECB, each block is still encrypted independently, and so there is no change in functionality.

I detected the slowness of the initialization of the encryptor with py-spy.