### PR TITLE
Fix encoding of integers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versioning].
 
 - Drop support for Python 3.7, Python 3.8 and PyPy3.8.
 - Add tests with Python 3.14 and PyPy3.11.
+- Improve performance by reducing the AES plaintext size. Note: this changes the
+  ordering of integers for existing seeds, which may be a breaking change depending
+  on the use case.
 
 ## [1.1.0] - 2022-12-29
 

--- a/src/shuffled/crypto.py
+++ b/src/shuffled/crypto.py
@@ -27,7 +27,7 @@ class AesRandomizer(Randomizer):
         self._encryptor = cipher.encryptor()
 
     def randomize(self, integer: int) -> int:
-        encoded = integer.to_bytes(128, byteorder="big")
+        encoded = integer.to_bytes(16, byteorder="big")
         encrypted = self._encryptor.update(encoded)
         return int.from_bytes(encrypted, byteorder="big")
 

--- a/tests/test_shuffled.py
+++ b/tests/test_shuffled.py
@@ -13,8 +13,21 @@ class TestShuffled:
         assert sorted(list(shuffled_range)) == list(range(range_size))
 
     @pytest.mark.parametrize(
-        "seed",
-        (b"", b"\x00", b"\x01"),
+        "seed, expected",
+        (
+            (
+                b"",
+                [4, 5, 6, 1, 2, 7, 8, 3, 10, 11, 13, 9, 16, 17, 12, 15, 18, 19, 14, 0],
+            ),
+            (
+                b"\x00",
+                [13, 14, 17, 7, 3, 15, 16, 6, 2, 5, 9, 12, 18, 10, 1, 19, 4, 0, 8, 11],
+            ),
+            (
+                b"\x01",
+                [11, 0, 9, 5, 6, 10, 19, 4, 13, 14, 8, 16, 17, 18, 15, 12, 1, 2, 7, 3],
+            ),
+        ),
     )
-    def test_seed(self, seed):
-        assert list(Shuffled(20, seed)) == list(Shuffled(20, seed))
+    def test_seed(self, seed, expected):
+        assert list(Shuffled(20, seed)) == expected


### PR DESCRIPTION
Too many bytes were previously used as plaintext, which made the computation unnecessarily inefficient. Test cases are added here to detect future changes in the ordering determined by the seed.

Note: this changes the ordering of integers done by this library for existing seeds, which could be a breaking change depending on the use case.